### PR TITLE
Update version to 0.3.1 and remove unused model_config from HealthCheckStatusSchema

### DIFF
--- a/modelib/core/schemas.py
+++ b/modelib/core/schemas.py
@@ -49,7 +49,6 @@ class HealthCheckStausSchema(pydantic.BaseModel):
 def pydantic_model_from_list_of_dicts(name, fields) -> typing.Type[pydantic.BaseModel]:
     """Create pydantic model from list of dicts"""
     fields_dict = {}
-    fields_dict["model_config"] = pydantic.ConfigDict(protected_namespaces=())
 
     for i, field in enumerate(fields):
         field_name = field.get("name")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelib"
-version = "0.3.0"
+version = "0.3.1"
 description = "A minimalist framework for online deployment of sklearn-like models"
 authors = ["Gabriel Guarisa <gabrielguarisa@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Bump the version to 0.3.1 and eliminate the unused `model_config` field.